### PR TITLE
Timeouts man...timeouts

### DIFF
--- a/kazurator/internals.py
+++ b/kazurator/internals.py
@@ -51,7 +51,7 @@ class Lock(object):
     def max_leases(self):
         return self._max_leases
 
-    def attempt_lock(self, timeout=0.2):
+    def attempt_lock(self, timeout=None):
         path = None
         finished = False
         lock_acquired = False
@@ -119,7 +119,10 @@ class Lock(object):
                 with mutex(self._lock):
                     try:
                         if self._client.exists(path_to_watch, self._watcher):
-                            self._watch_handle.wait(timeout)
+                            if timeout:
+                                self._watch_handle.wait(timeout)
+                            else:
+                                self._watch_handle.wait()
 
                             if not self._watch_handle.isSet():
                                 raise LockTimeout(

--- a/kazurator/mutex.py
+++ b/kazurator/mutex.py
@@ -3,7 +3,6 @@ from .internals import Lock, LockDriver
 from .utils import mutex
 
 DEFAULT_LOCK_NAME = "lock-"
-DEFAULT_TIMEOUT = 1.0
 
 
 class _LockData(object):
@@ -37,7 +36,7 @@ class Mutex(object):
         self._path = path
         self._sync_lock = client.handler.lock_object()
         self._thread_data = {}
-        self._timeout = kwargs.get("timeout", DEFAULT_TIMEOUT)
+        self._timeout = kwargs.get("timeout")
 
         self._lock = Lock(
             client,
@@ -60,6 +59,14 @@ class Mutex(object):
     @property
     def path(self):
         return self._path
+
+    @property
+    def timeout(self):
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, value):
+        self._timeout = value
 
     @property
     def is_acquired(self):

--- a/kazurator/read_write_lock.py
+++ b/kazurator/read_write_lock.py
@@ -31,7 +31,8 @@ class _Mutex(Mutex):
             path,
             max_leases,
             name=name,
-            driver=driver
+            driver=driver,
+            timeout=timeout
         )
 
     def get_participant_nodes(self):
@@ -52,6 +53,12 @@ class ReadWriteLock(object):
     @property
     def timeout(self):
         return self._timeout
+
+    @timeout.setter
+    def timeout(self, value):
+        self._timeout = value
+        self.read_lock.timeout = value
+        self.write_lock.timeout = value
 
     @lazyproperty
     def read_lock(self):
@@ -80,6 +87,11 @@ class ReadWriteLock(object):
             _LockDriver(),
             self.timeout
         )
+
+    def get_participant_nodes(self):
+        nodes = self.read_lock.get_participant_nodes()
+        nodes.extend(self.write_lock.get_participant_nodes())
+        return nodes
 
     def _read_is_acquirable_predicate(self, children, sequence_node_name):
         if self.write_lock.is_owned_by_current_thread:

--- a/kazurator/tests/test_internals.py
+++ b/kazurator/tests/test_internals.py
@@ -39,18 +39,18 @@ class TestLock(TestCase):
 
     def test_attempt_lock_returns_the_path_when_acquired(self):
         with self.internals("__READ__") as (_, lock):
-            assert lock.attempt_lock()
+            assert lock.attempt_lock(0.2)
 
     def test_attempt_lock_raises_lock_timeout_when_timeout_lapses(self):
         with self.internals("__READ__", max_leases=1) as (_, lock):
-            assert lock.attempt_lock()
+            assert lock.attempt_lock(0.2)
 
             with self.assertRaises(LockTimeout):
-                lock.attempt_lock()
+                lock.attempt_lock(0.2)
 
     def test_release_lock_deletes_the_znode(self):
         with self.internals("__READ__") as (client, lock):
-            assert lock.attempt_lock()
+            assert lock.attempt_lock(0.2)
 
             children = client.get_children(self.path)
             assert len(children) == 1


### PR DESCRIPTION
At some point I managed to subclass `Mutex` but not pass the timeout option to the initializer 🥇 

I've also changed the default timeout to be _forever_, since that's the case in curator and other libraries I've seen.